### PR TITLE
Gate menu item to ability

### DIFF
--- a/config/initializers/braintree.rb
+++ b/config/initializers/braintree.rb
@@ -6,7 +6,8 @@ if Spree::Backend::Config.respond_to?(:menu_items)
       [:paypal_braintree],
       'wrench',
       label: 'Braintree',
-      url: "#{ActionController::Base.relative_url_root}/solidus_paypal_braintree/configurations/list"
+      url: "#{ActionController::Base.relative_url_root}/solidus_paypal_braintree/configurations/list",
+      condition: -> { can?(:manage, SolidusPaypalBraintree::Transaction) }
     )
   end
 end


### PR DESCRIPTION
Menu items in Solidus should be conditionally displayed based on the current user's abilities. Here, we make the menu item for braintree conform to that convention.