### PR TITLE
Fix double Braintree in menu

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,8 @@ en:
       pay_pal_account: PayPal
     configurations:
       title: Braintree Configurations
-      tab: Braintree
+      tab:
+        braintree: Braintree
       update_success: Successfully updated Braintree configurations.
       update_error: An error occurred while updating Braintree configurations.
     gateway_rejection_reasons:

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -53,7 +53,8 @@ module SolidusPaypalBraintree
         Spree::Backend::Config.configure do |config|
           config.menu_items << config.class::MenuItem.new(
             [:braintree],
-            'cc-paypal',
+            'wrench',
+            label: 'braintree',
             url: '/solidus_paypal_braintree/configurations/list',
             condition: -> { can?(:list, SolidusPaypalBraintree::Configuration) }
           )


### PR DESCRIPTION
Before:
(Braintree is here twice)
<img width="282" alt="screen shot 2019-01-30 at 10 21 11 am" src="https://user-images.githubusercontent.com/11466782/51995689-cae21380-2478-11e9-94af-989633f988c6.png">

After:
![image](https://user-images.githubusercontent.com/11466782/51997772-fff06500-247c-11e9-91d7-b8cbaeef3e1c.png)

